### PR TITLE
Fixing argument description

### DIFF
--- a/dockerprettyps/__init__.py
+++ b/dockerprettyps/__init__.py
@@ -138,7 +138,7 @@ def _parsed_args():
         "--version",
         default=False,
         action='store_true',
-        help="Reverses the display order.")
+        help="Print the binary version information.")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Probably a typo

```
usage: docker-pretty-ps [-h] [-a] [-s] [-i INCLUDE] [-o [ORDER]] [-r] [-j]
                        [-v]
                        [search]

(...)
  -v, --version         Reverses the display order.
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```