### PR TITLE
Removing state pollution of `containers` by making a deepcopy

### DIFF
--- a/tests/test_dockerprettyps.py
+++ b/tests/test_dockerprettyps.py
@@ -1,6 +1,7 @@
 """Unit Tests for docker-pretty-ps
 
 """
+import copy
 from datetime import datetime, timedelta
 import os
 
@@ -343,7 +344,7 @@ class TestDockerPrettyPs(object):
         Tests the dockerprettyps.give_json() method, making sure we output the same data we would normally, but in JSON.
 
         """
-        containers = test_ps_data.ps_containers
+        containers = copy.deepcopy(test_ps_data.ps_containers)
         the_json = dockerprettyps.give_json(containers, CliArgs())
         assert the_json
 


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_give_json` by removing state pollution of `containers` by making a deepcopy.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_dockerprettyps.py::TestDockerPrettyPs::test_give_json`:

```
    def test_give_json(self):
        """
        Tests the dockerprettyps.give_json() method, making sure we output the same data we would normally, but in JSON.
    
        """
        containers = copy.copy(test_ps_data.ps_containers)
>       the_json = dockerprettyps.give_json(containers, CliArgs())

tests/test_dockerprettyps.py:348: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def give_json(containers, args):
        ...
        clean_date_containers = _json_container_dates(containers)
        more_cleaned = []
        for container in clean_date_containers:
>           more_cleaned.append(container.pop('color'))
E           KeyError: 'color'
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
